### PR TITLE
Force tmp screenshot overwrite

### DIFF
--- a/src/bin/blur.rs
+++ b/src/bin/blur.rs
@@ -71,7 +71,7 @@ fn main() -> Result<()> {
 /// Make a screenshot via scrot and capture the image (png) bytes.
 fn get_screenshot() -> Result<()> {
     let start = Instant::now();
-    Cmd::new("scrot --delay 0 --quality 95 --silent /tmp/blur-screenshot.jpg").run_success()?;
+    Cmd::new("scrot --overwrite --delay 0 --quality 95 --silent /tmp/blur-screenshot.jpg").run_success()?;
     debug!("scrot execution time: {}ms", start.elapsed().as_millis());
 
     Ok(())


### PR DESCRIPTION
Without this the `get_screenshot` function would create new tmp files with appended increasing numbers, which are never read by `load_image` since it uses a fixed filename.